### PR TITLE
Fix first prime in ProblemSeven

### DIFF
--- a/lib/problem_seven.rb
+++ b/lib/problem_seven.rb
@@ -5,6 +5,7 @@ require "problem_three"
 module ProblemSeven
 
   def ProblemSeven.nth_prime(n)
+    return 2 if n == 1
     i, count = 3, 2
     until count == n do 
       i += 2

--- a/spec/problem_seven_spec.rb
+++ b/spec/problem_seven_spec.rb
@@ -13,6 +13,13 @@ describe "ProblemSeven" do
 
     end
 
+    it "returns the first prime number" do
+      expect(ProblemSeven.nth_prime(1)).to eq(2)
+    end
+
+    it "returns the second prime number" do
+      expect(ProblemSeven.nth_prime(2)).to eq(3)
+    end
   end
 
 end


### PR DESCRIPTION
This PR fixes an issue in `ProblemSeven` where passing `1` to the `nth_prime` function would result in an infinite loop.

Now the function will properly return the first prime number, `2`, when given an input of `1`.

There is probably a better way to fix the problem, but this solution works.
